### PR TITLE
chore: symlink agent instruction files to canonical source

### DIFF
--- a/.clinerules/copilot-instructions.md
+++ b/.clinerules/copilot-instructions.md
@@ -1,1 +1,0 @@
-Open `@/.github/copilot-instructions.md`, read it and strictly follow the instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` as symlinks to `.github/copilot-instructions.md`
- Single canonical source for all AI agent instructions — no duplication, no indirection files

### Why these 3 files
- **AGENTS.md** — read by: OpenAI Codex CLI, Cursor, Windsurf, Cline, GitHub Copilot cloud agent, OpenCode, Devin, Amp, Zed
- **CLAUDE.md** — Claude Code reads only `CLAUDE.md`, not `AGENTS.md`
- **GEMINI.md** — Gemini CLI reads only `GEMINI.md` by default

### Windows note
With `core.symlinks=false` (default on Windows), git checks out symlinks as plain text files containing the target path. Developers on Windows who need proper symlink resolution should enable `git config core.symlinks true` with Developer Mode.