### PR TITLE
ci: set explicit GITHUB_TOKEN read-only permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
     branches: [main]
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Per SAP OSPO security hardening (CPAWGOSS-1209), set explicit `permissions: contents: read` on the CI workflow so it remains functional after the org-wide default flip on 27 May 2026.

The CI workflow only checks out the repo and runs tests — no write access needed.